### PR TITLE
Reduce YouTube API calls with caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,13 @@ agora/
 - Activer HTTPS
 - Mettre à jour régulièrement les dépendances
 
+## Cache des requêtes YouTube
+
+Pour réduire le nombre d'appels à l'API YouTube, l'application utilise une fonction
+`fetchWithCache` qui stocke les réponses dans le `localStorage` du navigateur.
+Chaque entrée est valide pendant 24 heures (`CACHE_TTL_SECONDS`). Passé ce délai,
+une nouvelle requête est envoyée afin de récupérer les dernières vidéos publiées.
+
 ## Contribution
 
 1. Fork le projet


### PR DESCRIPTION
## Summary
- add 24h `CACHE_TTL_SECONDS` constant and default to it in `fetchWithCache`
- remove per-call TTL values
- document the caching mechanism in README

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68414c8eff80832f998c94eb5bee49d2