### PR TITLE
Fix video modal centering

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -2073,10 +2073,13 @@ footer::before {
     position: relative;
     width: 90%;
     max-width: 1000px;
-    margin: 2rem auto;
+    margin: 5vh auto;
     background: rgba(20,30,50,0.98);
     border-radius: 16px;
+    max-height: 90vh;
     overflow: hidden;
+    display: flex;
+    flex-direction: column;
 }
 
 .close-modal {
@@ -2091,8 +2094,9 @@ footer::before {
 
 .video-player-container {
     position: relative;
-    padding-top: 56.25%; /* 16:9 aspect ratio */
     background: #000;
+    padding-top: 56.25%; /* 16:9 aspect ratio */
+    flex: none;
 }
 
 #video-player {
@@ -2106,6 +2110,8 @@ footer::before {
 .video-details {
     padding: 1.5rem;
     color: #fff;
+    overflow-y: auto;
+    flex: 1 1 auto;
 }
 
 .video-details h2 {
@@ -2178,6 +2184,17 @@ footer::before {
     .modal-content {
         width: 95%;
         margin: 1rem auto;
+        height: auto;
+        max-height: 90vh;
+        overflow-x: hidden;
+        overflow-y: auto;
+        display: block;
+    }
+
+    .video-player-container {
+        padding-top: 56.25%;
+        height: auto;
+        flex: none;
     }
     
     .video-actions {
@@ -2985,7 +3002,10 @@ body.home-bg {
     width: 90%;
     max-width: 100%;
     margin: 1rem auto;
+    height: 90vh;
     overflow: hidden;
+    display: flex;
+    flex-direction: column;
 }
 
 /* Fix pour les formulaires */
@@ -3021,6 +3041,11 @@ body.home-bg {
     
     .modal-content {
         width: 95%;
+        height: auto;
+        max-height: 90vh;
+        overflow-x: hidden;
+        overflow-y: auto;
+        display: block;
     }
 }
 
@@ -3047,6 +3072,13 @@ body.home-bg {
         padding: 0.5rem;
         margin: 0;
         overflow-x: hidden;
+        height: auto;
+    }
+
+    .modal-content {
+        max-height: 90vh;
+        overflow-y: auto;
+        display: block;
     }
 
     /* Fix pour les widgets Discord */
@@ -3120,6 +3152,11 @@ body.home-bg {
         width: 95%;
         margin: 0.5rem auto;
         padding: 0.5rem;
+        max-height: 90vh;
+        overflow-x: hidden;
+        overflow-y: auto;
+        display: block;
+        height: auto;
     }
 
     /* Fix pour les grilles */


### PR DESCRIPTION
## Summary
- tweak modal content to be vertically centered and not exceed viewport
- keep video player at 16:9 ratio so it fits the card

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6842ab1c8eac832fbcc6b0a7f493a6c3